### PR TITLE
Add benchmark that exercises large frame transfers

### DIFF
--- a/tarpc-iceoryx2-transport/src/lib.rs
+++ b/tarpc-iceoryx2-transport/src/lib.rs
@@ -46,7 +46,7 @@ pub struct IceoryxConfig {
 impl Default for IceoryxConfig {
     fn default() -> Self {
         Self {
-            max_message_size: 64 * 1024,
+            max_message_size: 64 * 1024 * 1024,
             subscriber_buffer_size: 2,
             poll_interval: Duration::from_micros(50),
         }


### PR DESCRIPTION
## Summary
- extend the Arithmetic service with a `process_frame` RPC that reports the frame length
- add a Criterion benchmark that round-trips an uncompressed 1080p RGB frame

## Testing
- cargo fmt --all
- RUSTFLAGS="-D warnings" cargo test --locked --quiet
- cargo clippy --all-targets -- -D warnings
- cargo llvm-cov --locked --quiet

------
https://chatgpt.com/codex/tasks/task_e_68cc276895b48320b570a35876bcfad6