### PR TITLE
Add standalone adder client/server binaries

### DIFF
--- a/tarpc-iceoryx2-transport/src/addition.rs
+++ b/tarpc-iceoryx2-transport/src/addition.rs
@@ -1,0 +1,18 @@
+use tarpc::context;
+
+/// Tarpc service that adds two 64-bit integers.
+#[tarpc::service]
+pub trait Adder {
+    /// Adds two signed integers and returns the sum.
+    async fn add(x: i64, y: i64) -> i64;
+}
+
+/// Server-side implementation of the [`Adder`] service.
+#[derive(Clone, Default)]
+pub struct AdderService;
+
+impl Adder for AdderService {
+    async fn add(self, _: context::Context, x: i64, y: i64) -> i64 {
+        x + y
+    }
+}

--- a/tarpc-iceoryx2-transport/src/bin/adder_client.rs
+++ b/tarpc-iceoryx2-transport/src/bin/adder_client.rs
@@ -1,0 +1,77 @@
+use std::{env, process};
+
+use tarpc::context;
+use tarpc_iceoryx2_transport::{
+    IceoryxConfig, IceoryxStream, Role, addition::AdderClient, bincode_transport,
+};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+fn usage(program: &str) {
+    eprintln!("Usage: {program} <service-name> <x> <y> [iterations]");
+}
+
+fn into_box_error<E>(err: E) -> BoxError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    Box::new(err)
+}
+
+fn parse_i64(value: Option<String>, name: &str, program: &str) -> i64 {
+    let raw = value.unwrap_or_else(|| {
+        usage(program);
+        process::exit(64);
+    });
+
+    raw.parse::<i64>().unwrap_or_else(|err| {
+        eprintln!("Failed to parse {name} as i64: {err}");
+        process::exit(65);
+    })
+}
+
+fn parse_iterations(value: Option<String>) -> usize {
+    match value {
+        Some(raw) => raw.parse::<usize>().unwrap_or_else(|err| {
+            eprintln!("Failed to parse iterations as usize: {err}");
+            process::exit(65);
+        }),
+        None => 1,
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), BoxError> {
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "adder_client".to_string());
+
+    let service_name = args.next().unwrap_or_else(|| {
+        usage(&program);
+        process::exit(64);
+    });
+    let x = parse_i64(args.next(), "x", &program);
+    let y = parse_i64(args.next(), "y", &program);
+    let iterations = parse_iterations(args.next());
+
+    if args.next().is_some() {
+        usage(&program);
+        process::exit(64);
+    }
+
+    let stream = IceoryxStream::connect(&service_name, Role::Client, IceoryxConfig::default())
+        .map_err(into_box_error)?;
+    let transport = bincode_transport(stream);
+    let client = AdderClient::new(Default::default(), transport).spawn();
+
+    let mut last_result = 0i64;
+    for _ in 0..iterations {
+        last_result = client
+            .add(context::current(), x, y)
+            .await
+            .map_err(into_box_error)?;
+    }
+
+    println!("{last_result}");
+
+    Ok(())
+}

--- a/tarpc-iceoryx2-transport/src/bin/adder_server.rs
+++ b/tarpc-iceoryx2-transport/src/bin/adder_server.rs
@@ -1,0 +1,40 @@
+use std::{env, io, process};
+
+use futures::StreamExt;
+use tarpc::server::{BaseChannel, Channel};
+use tarpc_iceoryx2_transport::{
+    IceoryxConfig, IceoryxStream, Role,
+    addition::{Adder, AdderService},
+    bincode_transport,
+};
+
+fn usage(program: &str) {
+    eprintln!("Usage: {program} <service-name>");
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> io::Result<()> {
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "adder_server".to_string());
+    let service_name = match args.next() {
+        Some(name) => name,
+        None => {
+            usage(&program);
+            process::exit(64);
+        }
+    };
+
+    println!("Starting adder server on `{service_name}`");
+
+    let stream = IceoryxStream::connect(&service_name, Role::Server, IceoryxConfig::default())?;
+    let transport = bincode_transport(stream);
+
+    BaseChannel::with_defaults(transport)
+        .execute(AdderService.serve())
+        .for_each(|fut| async move {
+            tokio::spawn(fut);
+        })
+        .await;
+
+    Ok(())
+}

--- a/tarpc-iceoryx2-transport/src/lib.rs
+++ b/tarpc-iceoryx2-transport/src/lib.rs
@@ -458,7 +458,7 @@ fn to_io_error<E: fmt::Display>(err: E) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::addition::Adder;
+    use crate::addition::{Adder, AdderRequest, AdderResponse};
     use futures::StreamExt;
     use tarpc::{
         Transport, context,
@@ -473,29 +473,20 @@ mod tests {
         async fn add(x: i32, y: i32) -> i32;
     }
 
-    #[derive(Clone)]
-    struct ArithmeticImpl;
-
-    impl Arithmetic for ArithmeticImpl {
-        async fn add(self, _: context::Context, x: i32, y: i32) -> i32 {
-            x + y
-        }
-    }
-
     fn unique_service_name() -> String {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         format!("tarpc/test/{}/{}", std::process::id(), id)
     }
 
-    type ServerSink = tarpc::Response<ArithmeticResponse>;
-    type ServerItem = tarpc::ClientMessage<ArithmeticRequest>;
-    type ClientSink = tarpc::ClientMessage<ArithmeticRequest>;
-    type ClientItem = tarpc::Response<ArithmeticResponse>;
+    type ServerSink = tarpc::Response<AdderResponse>;
+    type ServerItem = tarpc::ClientMessage<AdderRequest>;
+    type ClientSink = tarpc::ClientMessage<AdderRequest>;
+    type ClientItem = tarpc::Response<AdderResponse>;
 
     async fn run_roundtrip<ServerTransport, ClientTransport, MakeServer, MakeClient>(
         make_server_transport: MakeServer,
-        make_client_transport: MakeClient,
+        _make_client_transport: MakeClient,
     ) -> io::Result<()>
     where
         ServerTransport: Transport<ServerSink, ServerItem> + Send + 'static,

--- a/tarpc-iceoryx2-transport/tests/adder_binaries.rs
+++ b/tarpc-iceoryx2-transport/tests/adder_binaries.rs
@@ -1,0 +1,64 @@
+use std::{
+    error::Error,
+    process::{Child, Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+struct ChildGuard {
+    child: Option<Child>,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[test]
+fn client_and_server_binaries_add_numbers() -> Result<(), Box<dyn Error>> {
+    let server_bin = env!("CARGO_BIN_EXE_adder_server");
+    let client_bin = env!("CARGO_BIN_EXE_adder_client");
+    let service_name = format!(
+        "tarpc/test/bin/{}/{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    );
+
+    let server_child = Command::new(server_bin)
+        .arg(&service_name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut server = ChildGuard {
+        child: Some(server_child),
+    };
+
+    thread::sleep(Duration::from_millis(500));
+
+    let output = Command::new(client_bin)
+        .arg(&service_name)
+        .arg("20")
+        .arg("22")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "client exited with failure: {:?}",
+        output
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout.trim(), "42");
+
+    if let Some(mut child) = server.child.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a shared Adder service definition with a default implementation
- introduce adder_client and adder_server binaries that talk over the iceoryx transport
- add an integration test that spawns the new binaries to verify cross-process RPC communication

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test --locked --quiet
- cargo llvm-cov --locked --quiet

------
https://chatgpt.com/codex/tasks/task_e_68cc3dc2da748320bd8407a37fb39584