### PR TITLE
Use event-driven wakeups for IceoryxStream

### DIFF
--- a/tarpc-iceoryx2-transport/Cargo.lock
+++ b/tarpc-iceoryx2-transport/Cargo.lock
@@ -1397,6 +1397,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "speedy"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,7 +1568,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/tarpc-iceoryx2-transport/Cargo.toml
+++ b/tarpc-iceoryx2-transport/Cargo.toml
@@ -16,7 +16,7 @@ tarpc = { version = "0.37", default-features = false, features = [
     "serde1",
     "tokio1",
 ] }
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
## Summary
- enable tokio's net feature and wire IceoryxStream up to notifier/listener-based wakeups
- replace the busy-wait read loop with an AsyncFd-backed event listener and notify peers during shutdown
- add helpers for notification service naming along with unit tests covering the naming scheme

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test --locked --quiet *(fails: `tarpc_roundtrip_postcard`, `tarpc_roundtrip_bitcode` -> `DeadlineExceeded` as on main)*
- cargo llvm-cov --locked --quiet *(fails: `cargo-llvm-cov` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc69c8c5e48320802d7e3284e81efa